### PR TITLE
Sanitize first name in welcome message

### DIFF
--- a/public/commands/NewchatmembersCommand.php
+++ b/public/commands/NewchatmembersCommand.php
@@ -64,7 +64,7 @@ class NewchatmembersCommand extends SystemCommand
         $this->kickDisallowedBots($new_bots);
 
         $new_users_text = implode(', ', array_map(function (User $new_user) {
-            return '<a href="tg://user?id=' . $new_user->getId() . '">' . htmlentities($new_user->getFirstName()) . '</a>';
+            return '<a href="tg://user?id=' . $new_user->getId() . '">' . filter_var($new_user->getFirstName(), FILTER_SANITIZE_SPECIAL_CHARS) . '</a>';
         }, $new_users));
 
         if ($new_users_text === '') {


### PR DESCRIPTION
Maybe using this method will prevent https://github.com/php-telegram-bot/support-bot/issues/11#issuecomment-365838558 (image)

Been using it with my bots instead of `htmlentities()` and I haven't found any issues with it so far.