### PR TITLE
Remove existing welcome messages and send/leave only the latest one

### DIFF
--- a/public/commands/NewchatmembersCommand.php
+++ b/public/commands/NewchatmembersCommand.php
@@ -11,6 +11,7 @@
 namespace Longman\TelegramBot\Commands\SystemCommands;
 
 use Longman\TelegramBot\Commands\SystemCommand;
+use Longman\TelegramBot\DB;
 use Longman\TelegramBot\Entities\ChatMember;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Entities\User;
@@ -34,7 +35,7 @@ class NewchatmembersCommand extends SystemCommand
     /**
      * @var string
      */
-    protected $version = '0.2.0';
+    protected $version = '0.3.0';
 
     /**
      * @var int
@@ -47,6 +48,11 @@ class NewchatmembersCommand extends SystemCommand
     private $user_id;
 
     /**
+     * @var string
+     */
+    private $group_name = 'PHP Telegram Support Bot';
+
+    /**
      * @inheritdoc
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
@@ -56,26 +62,57 @@ class NewchatmembersCommand extends SystemCommand
         $this->chat_id = $message->getChat()->getId();
         $this->user_id = $message->getFrom()->getId();
 
-        $group_name = $message->getChat()->getTitle();
+        $this->group_name = $message->getChat()->getTitle();
 
         ['users' => $new_users, 'bots' => $new_bots] = $this->getNewUsersAndBots();
 
         // Kick bots if they weren't added by an admin.
         $this->kickDisallowedBots($new_bots);
 
+        return $this->refreshWelcomeMessage($new_users);
+    }
+
+    /**
+     * Remove existing and send new welcome message.
+     *
+     * @param array $new_users
+     *
+     * @return ServerResponse
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    private function refreshWelcomeMessage(array $new_users): ServerResponse
+    {
+        if (empty($new_users)) {
+            return Request::emptyResponse();
+        }
+
         $new_users_text = implode(', ', array_map(function (User $new_user) {
             return '<a href="tg://user?id=' . $new_user->getId() . '">' . filter_var($new_user->getFirstName(), FILTER_SANITIZE_SPECIAL_CHARS) . '</a>';
         }, $new_users));
 
-        if ($new_users_text === '') {
-            return Request::emptyResponse();
-        }
-
-        $text = "Welcome {$new_users_text} to the <b>{$group_name}</b> group\n";
+        $text = "Welcome {$new_users_text} to the <b>{$this->group_name}</b> group\n";
         $text .= 'Please remember that this is <b>NOT</b> the Telegram Support Chat.' . PHP_EOL;
         $text .= 'Read the <a href="https://telegram.me/PHP_Telegram_Support_Bot?start=">Rules</a> that apply here.';
 
-        return $this->replyToChat($text, ['parse_mode' => 'HTML', 'disable_web_page_preview' => true]);
+        $welcome_message_sent = $this->replyToChat($text, ['parse_mode' => 'HTML', 'disable_web_page_preview' => true]);
+        if (!$welcome_message_sent->isOk()) {
+            return Request::emptyResponse();
+        }
+
+        $welcome_message = $welcome_message_sent->getResult();
+
+        $new_message_id = $welcome_message->getMessageId();
+        $chat_id        = $welcome_message->getChat()->getId();
+
+        if ($new_message_id && $chat_id) {
+            if ($message_id = $this->getSimpleOption('welcome_message_id')) {
+                Request::deleteMessage(compact('chat_id', 'message_id'));
+            }
+
+            $this->setSimpleOption('welcome_message_id', $new_message_id);
+        }
+
+        return $welcome_message_sent;
     }
 
     /**
@@ -138,5 +175,45 @@ class NewchatmembersCommand extends SystemCommand
                 'user_id' => $bot->getId(),
             ]);
         }
+    }
+
+    /**
+     * Get a simple option value.
+     *
+     * @todo: Move into core!
+     *
+     * @param string $name
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    private function getSimpleOption($name, $default = false)
+    {
+        return DB::getPdo()->query("
+            SELECT `value`
+            FROM `simple_options`
+            WHERE `name` = '{$name}'
+        ")->fetchColumn() ?? $default;
+    }
+
+    /**
+     * Set a simple option value.
+     *
+     * @todo: Move into core!
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return bool
+     */
+    private function setSimpleOption($name, $value): bool
+    {
+        return DB::getPdo()->prepare("
+            INSERT INTO `simple_options`
+            (`name`, `value`) VALUES (?, ?)
+            ON DUPLICATE KEY UPDATE
+            `name` = VALUES(`name`),
+            `value` = VALUES(`value`)
+        ")->execute([$name, $value]);
     }
 }

--- a/structure.sql
+++ b/structure.sql
@@ -1,0 +1,10 @@
+-- First import structure.sql from the core repo!
+
+CREATE TABLE IF NOT EXISTS `simple_options` (
+  `id` bigint UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Unique option identifier',
+  `name` VARCHAR(64) COMMENT 'Unique option name to fetch the value',
+  `value` TEXT COMMENT 'Value saved in the current option',
+
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;


### PR DESCRIPTION
This PR prevents the group from being filled with welcome messages when new users join.
Thanks so much @chuv1 for your suggestion!!

Fixes #16 

A new table called `simple_options` (in the new `structure.sql` file) must be added to the DB.

(This options functionality should become part of core, as discussed in https://github.com/php-telegram-bot/core/issues/441 and https://github.com/php-telegram-bot/core/issues/694, but with more thought put into it, especially regarding command-specific/global/user options etc.)