### PR TITLE
Fix deprecated Newchatmembers system command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- Deprecated system commands are now executed via `GenericmessageCommand`.
 ### Security
 
 ## [0.3.0] - 2019-07-30

--- a/commands/GenericmessageCommand.php
+++ b/commands/GenericmessageCommand.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the PHP Telegram Support Bot.
+ *
+ * (c) PHP Telegram Bot Team (https://github.com/php-telegram-bot)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\SystemCommands;
+
+use Longman\TelegramBot\Commands\SystemCommand;
+use Longman\TelegramBot\Entities\ServerResponse;
+use Longman\TelegramBot\Exception\TelegramException;
+use Longman\TelegramBot\Request;
+
+/**
+ * Generic message command
+ */
+class GenericmessageCommand extends SystemCommand
+{
+    /**
+     * @var string
+     */
+    protected $name = 'genericmessage';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Handle generic message';
+
+    /**
+     * @var string
+     */
+    protected $version = '0.1.0';
+
+    /**
+     * Execute command
+     *
+     * @return ServerResponse
+     * @throws TelegramException
+     */
+    public function execute(): ServerResponse
+    {
+        // Handle new chat members.
+        if ($this->getMessage()->getNewChatMembers()) {
+            return $this->getTelegram()->executeCommand('newchatmembers');
+        }
+
+        return Request::emptyResponse();
+    }
+}


### PR DESCRIPTION
The command is now called from GenericmessageCommand.