### PR TITLE
Rules approval for new users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,10 @@ TG_GITHUB_AUTH_TOKEN='github-token'
 # Telegram Payments
 TG_PAYMENT_PROVIDER_TOKEN='123:TEST:abc'
 
+# Support group activation expiry and ban times
+TG_SUPPORT_GROUP_ACTIVATION_EXPIRE_TIME='15 min'
+TG_SUPPORT_GROUP_BAN_TIME='1 day'
+
 # URLs
 TG_URL_DONATE='https://...'
 TG_URL_PATREON='https://...'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 
 ## [Unreleased]
 ### Added
+- Rules must be agreed to before allowing a user to post in the group.
 ### Changed
 ### Deprecated
 ### Removed

--- a/commands/CallbackqueryCommand.php
+++ b/commands/CallbackqueryCommand.php
@@ -51,11 +51,8 @@ class CallbackqueryCommand extends SystemCommand
         parse_str($callback_query->getData(), $callback_data);
 
         if ('donate' === $callback_data['command']) {
-            DonateCommand::createPaymentInvoice(
-                $callback_query->getFrom()->getId(),
-                $callback_data['amount'],
-                $callback_data['currency']
-            );
+            return DonateCommand::handleCallbackQuery($callback_query, $callback_data);
+        }
 
         if ('rules' === $callback_data['command']) {
             return RulesCommand::handleCallbackQuery($callback_query, $callback_data);

--- a/commands/CallbackqueryCommand.php
+++ b/commands/CallbackqueryCommand.php
@@ -13,6 +13,7 @@ namespace Longman\TelegramBot\Commands\SystemCommands;
 
 use Longman\TelegramBot\Commands\SystemCommand;
 use Longman\TelegramBot\Commands\UserCommands\DonateCommand;
+use Longman\TelegramBot\Commands\UserCommands\RulesCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 
 /**
@@ -47,18 +48,17 @@ class CallbackqueryCommand extends SystemCommand
     public function execute(): ServerResponse
     {
         $callback_query = $this->getCallbackQuery();
-        parse_str($callback_query->getData(), $data);
+        parse_str($callback_query->getData(), $callback_data);
 
-        if ('donate' === $data['command']) {
+        if ('donate' === $callback_data['command']) {
             DonateCommand::createPaymentInvoice(
                 $callback_query->getFrom()->getId(),
-                $data['amount'],
-                $data['currency']
+                $callback_data['amount'],
+                $callback_data['currency']
             );
 
-            return $callback_query->answer([
-                'text' => 'Awesome, an invoice has been sent to you.',
-            ]);
+        if ('rules' === $callback_data['command']) {
+            return RulesCommand::handleCallbackQuery($callback_query, $callback_data);
         }
 
         return $callback_query->answer();

--- a/commands/DonateCommand.php
+++ b/commands/DonateCommand.php
@@ -16,6 +16,7 @@ namespace Longman\TelegramBot\Commands\UserCommands;
 use JsonException;
 use LitEmoji\LitEmoji;
 use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Entities\CallbackQuery;
 use Longman\TelegramBot\Entities\InlineKeyboard;
 use Longman\TelegramBot\Entities\Payments\LabeledPrice;
 use Longman\TelegramBot\Entities\Payments\SuccessfulPayment;
@@ -56,6 +57,27 @@ class DonateCommand extends UserCommand
      * @var bool
      */
     protected $private_only = true;
+
+    /**
+     * Handle the callback queries regarding the /donate command.
+     *
+     * @param CallbackQuery $callback_query
+     * @param array         $callback_data
+     *
+     * @return ServerResponse
+     */
+    public static function handleCallbackQuery(CallbackQuery $callback_query, array $callback_data): ServerResponse
+    {
+        self::createPaymentInvoice(
+            $callback_query->getFrom()->getId(),
+            $callback_data['amount'],
+            $callback_data['currency']
+        );
+
+        return $callback_query->answer([
+            'text' => 'Awesome, an invoice has been sent to you.',
+        ]);
+    }
 
     /**
      * @return ServerResponse

--- a/commands/GenericmessageCommand.php
+++ b/commands/GenericmessageCommand.php
@@ -17,6 +17,7 @@ use Longman\TelegramBot\Commands\SystemCommand;
 use Longman\TelegramBot\Commands\UserCommands\DonateCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Exception\TelegramException;
+use Longman\TelegramBot\Request;
 
 /**
  * Generic message command
@@ -51,7 +52,11 @@ class GenericmessageCommand extends SystemCommand
 
         // Handle new chat members.
         if ($message->getNewChatMembers()) {
+            $this->deleteThisMessage(); // Service message.
             return $this->getTelegram()->executeCommand('newchatmembers');
+        }
+        if ($message->getLeftChatMember()) {
+            $this->deleteThisMessage(); // Service message.
         }
 
         // Handle successful payment of donation.
@@ -65,5 +70,18 @@ class GenericmessageCommand extends SystemCommand
         }
 
         return parent::execute();
+    }
+
+    /**
+     * Delete the current message.
+     *
+     * @return ServerResponse
+     */
+    private function deleteThisMessage(): ServerResponse
+    {
+        return Request::deleteMessage([
+            'chat_id'    => $this->getMessage()->getChat()->getId(),
+            'message_id' => $this->getMessage()->getMessageId(),
+        ]);
     }
 }

--- a/commands/NewchatmembersCommand.php
+++ b/commands/NewchatmembersCommand.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Longman\TelegramBot\Commands\SystemCommands;
 
+use LitEmoji\LitEmoji;
 use Longman\TelegramBot\Commands\SystemCommand;
 use Longman\TelegramBot\Entities\ChatMember;
+use Longman\TelegramBot\Entities\InlineKeyboard;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Entities\User;
 use Longman\TelegramBot\Exception\TelegramException;
@@ -39,7 +41,7 @@ class NewchatmembersCommand extends SystemCommand
     /**
      * @var string
      */
-    protected $version = '0.4.0';
+    protected $version = '0.5.0';
 
     /**
      * @var int
@@ -94,11 +96,20 @@ class NewchatmembersCommand extends SystemCommand
             return '<a href="tg://user?id=' . $new_user->getId() . '">' . filter_var($new_user->getFirstName(), FILTER_SANITIZE_SPECIAL_CHARS) . '</a>';
         }, $new_users));
 
-        $text = "Welcome {$new_users_text} to the <b>{$this->group_name}</b> group\n";
-        $text .= 'Please remember that this is <b>NOT</b> the Telegram Support Chat.' . PHP_EOL;
-        $text .= 'Read the <a href="https://t.me/PHP_Telegram_Support_Bot?start=rules">Rules</a> that apply here.';
+        $text = ":wave: Welcome {$new_users_text} to the <b>{$this->group_name}</b> group\n\n";
+        $text .= 'Please read and agree to the rules before posting here, thank you!';
 
-        $welcome_message_sent = $this->replyToChat($text, ['parse_mode' => 'HTML', 'disable_web_page_preview' => true]);
+        $welcome_message_sent = $this->replyToChat(
+            LitEmoji::encodeUnicode($text),
+            [
+                'parse_mode'               => 'HTML',
+                'disable_web_page_preview' => true,
+                'disable_notification'     => true,
+                'reply_markup'             => new InlineKeyboard([
+                    ['text' => LitEmoji::encodeUnicode(':orange_book: Read the Rules'), 'url' => 'https://t.me/PHP_Telegram_Support_Bot?start=rules'],
+                ]),
+            ]
+        );
         if (!$welcome_message_sent->isOk()) {
             return Request::emptyResponse();
         }

--- a/commands/RulesCommand.php
+++ b/commands/RulesCommand.php
@@ -13,8 +13,14 @@ declare(strict_types=1);
 
 namespace Longman\TelegramBot\Commands\UserCommands;
 
+use LitEmoji\LitEmoji;
 use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\DB;
+use Longman\TelegramBot\Entities\CallbackQuery;
+use Longman\TelegramBot\Entities\ChatPermissions;
+use Longman\TelegramBot\Entities\InlineKeyboard;
 use Longman\TelegramBot\Entities\ServerResponse;
+use Longman\TelegramBot\Request;
 
 /**
  * User "/rules" command
@@ -46,28 +52,102 @@ class RulesCommand extends UserCommand
      */
     protected $private_only = true;
 
+    public static function handleCallbackQuery(CallbackQuery $callback_query, array $callback_data): ?ServerResponse
+    {
+        if ('agree' === $callback_data['action'] ?? null) {
+            $message         = $callback_query->getMessage();
+            $chat_id         = $message->getChat()->getId();
+            $clicked_user_id = $callback_query->getFrom()->getId();
+
+            // If the user is already activated, keep the initial activation date.
+            $activated = DB::getPdo()->prepare("
+                UPDATE " . TB_USER . "
+                SET `activated_at` = ?
+                WHERE `id` = ?
+                  AND `activated_at` IS NULL
+            ")->execute([date('Y-m-d H:i:s'), $clicked_user_id]);
+
+            if (!$activated) {
+                return $callback_query->answer([
+                    'text'       => 'Something went wrong, please try again later.',
+                    'show_alert' => true,
+                ]);
+            }
+
+            Request::editMessageReplyMarkup([
+                'chat_id'      => $chat_id,
+                'message_id'   => $message->getMessageId(),
+                'reply_markup' => new InlineKeyboard([
+                    ['text' => LitEmoji::encodeUnicode(':white_check_mark: Ok! Go to Bot Support group...'), 'url' => 'https://t.me/PHP_Telegram_Bot_Support'],
+                ]),
+            ]);
+
+            Request::restrictChatMember([
+                'chat_id'     => getenv('TG_SUPPORT_GROUP_ID'),
+                'user_id'     => $clicked_user_id,
+                'permissions' => new ChatPermissions([
+                    'can_send_messages'         => true,
+                    'can_send_media_messages'   => true,
+                    'can_add_web_page_previews' => true,
+                    'can_invite_users'          => true,
+                ]),
+            ]);
+
+            return $callback_query->answer([
+                'text'       => 'Thanks for agreeing to the rules. You may now post in the support group.',
+                'show_alert' => true,
+            ]);
+        }
+
+        return $callback_query->answer();
+    }
+
     /**
      * @inheritdoc
      */
     public function execute(): ServerResponse
     {
-        $text = <<<EOT
+        $text = "
 Rules:  `English only | No Spamming or Nonsense Posting | No Bots`
 
-¬ **English only**
-Please keep your conversations in english inside this chatroom, otherwise your message will be deleted
+**:uk: English only**
+Please keep your conversations in English inside this chatroom, otherwise your message will be deleted.
 
-¬ **No Spamming or Nonsense Posting** 
-Don't spam Stickers or send Messages with useless Content. When repeated you may be kicked or banned
+**:do_not_litter: No Spamming or Nonsense Posting**
+Don't spam or send Messages with useless Content. When repeated you may be kicked or banned.
 
-¬ **No Bots**
+**:robot: No Bots**
 Please do not add a Bot inside this Chat without asking the Admins first. Feel free to mention the Bot in a Message
 
-Also keep in mind that this PHP Telegram Bot Support Chat applies only for the PHP Telegram Bot library
-https://github.com/php-telegram-bot/core
+Also keep in mind that the [PHP Telegram Bot Support Chat](https://t.me/PHP_Telegram_Bot_Support) applies only for the [PHP Telegram Bot library](https://github.com/php-telegram-bot/core).
+";
 
-EOT;
+        $data = [
+            'parse_mode'               => 'markdown',
+            'disable_web_page_preview' => true,
+        ];
 
-        return $this->replyToChat($text, ['parse_mode' => 'markdown']);
+        if (!self::userHasAgreedToRules($this->getMessage()->getFrom()->getId())) {
+            $text                 .= PHP_EOL . 'You **must agree** to these rules to post in the support group. Simply click the button below.';
+            $data['reply_markup'] = new InlineKeyboard([
+                ['text' => LitEmoji::encodeUnicode(':+1: I Agree to the Rules'), 'callback_data' => 'command=rules&action=agree'],
+            ]);
+        }
+
+        return $this->replyToChat(LitEmoji::encodeUnicode($text), $data);
+    }
+
+    protected static function userHasAgreedToRules(int $user_id): bool
+    {
+        $statement = DB::getPdo()->prepare('
+            SELECT `activated_at`
+            FROM `' . TB_USER . '`
+            WHERE `id` = ?
+              AND `activated_at` IS NOT NULL
+        ');
+        $statement->execute([$user_id]);
+        $agreed = $statement->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+        return !empty($agreed);
     }
 }

--- a/commands/StartCommand.php
+++ b/commands/StartCommand.php
@@ -53,6 +53,10 @@ class StartCommand extends SystemCommand
      */
     public function execute(): ServerResponse
     {
+        if ('activate' === $this->getMessage()->getText(true)) {
+            return $this->getTelegram()->executeCommand('activate');
+        }
+
         if ('rules' === $this->getMessage()->getText(true)) {
             return $this->getTelegram()->executeCommand('rules');
         }

--- a/cron.php
+++ b/cron.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the PHP Telegram Support Bot.
+ *
+ * (c) PHP Telegram Bot Team (https://github.com/php-telegram-bot)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace TelegramBot\SupportBot;
+
+use Dotenv\Dotenv;
+use Longman\TelegramBot\Telegram;
+use Longman\TelegramBot\TelegramLog;
+
+// Composer autoloader.
+require_once __DIR__ . '/vendor/autoload.php';
+Dotenv::create(__DIR__)->load();
+
+try {
+    $telegram = new Telegram(getenv('TG_API_KEY'), getenv('TG_BOT_USERNAME'));
+    $telegram->enableMySql([
+        'host'     => getenv('TG_DB_HOST'),
+        'port'     => getenv('TG_DB_PORT'),
+        'user'     => getenv('TG_DB_USER'),
+        'password' => getenv('TG_DB_PASSWORD'),
+        'database' => getenv('TG_DB_DATABASE'),
+    ]);
+
+    // Handle expired activations.
+    Helpers::handleExpiredActivations();
+} catch (\Throwable $e) {
+    TelegramLog::error($e->getMessage());
+}

--- a/structure.sql
+++ b/structure.sql
@@ -8,3 +8,5 @@ CREATE TABLE IF NOT EXISTS `simple_options` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+ALTER TABLE `user` ADD COLUMN `activated_at` TIMESTAMP NULL COMMENT 'Timestamp when the user has agreed to the rules and has been allowed to post in the support group.';

--- a/structure.sql
+++ b/structure.sql
@@ -9,4 +9,7 @@ CREATE TABLE IF NOT EXISTS `simple_options` (
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
+-- Version Unreleased
+ALTER TABLE `user` ADD COLUMN `joined_at` TIMESTAMP NULL COMMENT 'Timestamp when the user joined the support group.';
+ALTER TABLE `user` ADD COLUMN `kicked_at` TIMESTAMP NULL COMMENT 'Timestamp when the user was kicked from the support group.';
 ALTER TABLE `user` ADD COLUMN `activated_at` TIMESTAMP NULL COMMENT 'Timestamp when the user has agreed to the rules and has been allowed to post in the support group.';


### PR DESCRIPTION
The rules need to be approved (in a private bot chat) to get the permissions necessary for posting in the group.

At the moment, a simple click on an "I Agree" button is all that is needed.

todo:
- [x] Kick user after a defined expiry period.
- [ ] We'll test it like this, and if need be because of excess spam users, create a more complex activation.

---

*Initial rules message, showing the "I Agree" button*

![rules](https://user-images.githubusercontent.com/9423417/87206501-637cf400-c2f9-11ea-9d60-b053d3334176.png)

---

*After clicking "I Agree", an alert is displayed and the button now links to the group.*

![ok-alert](https://user-images.githubusercontent.com/9423417/87206495-61b33080-c2f9-11ea-97db-83b921e38df8.png)
![ok-button](https://user-images.githubusercontent.com/9423417/87206499-62e45d80-c2f9-11ea-9f7e-a29a473ce061.png)

Closes #19